### PR TITLE
Adding settings/features for: Splits on Boss Kill, Multiweapon House Splits, and Routed (Per Chamber) Splits

### DIFF
--- a/hades.asl
+++ b/hades.asl
@@ -2,6 +2,8 @@
 	Credits
 		Sebastien S. (SystemFailu.re) : Creating main script, reversing engine.
 		ellomenop : Doing splits, helping test & misc. bug fixes.
+		Museus: Routed splitting
+		cgull: House splits + splits on boss kill
 */
 
 state("Hades")
@@ -182,19 +184,24 @@ start
 
 split
 {
+  // Credits: Museus
+
+  // routed splitting (if setting selected), splits every room transition after start
+  if (settings["routed"] && !(vars.current_map == vars.old_map))
+  {
+	  return true;
+  }
+
+  // Credits: cgull
+  // resetting boss kill boolean, as sometimes it gets reset to true after splitting
   if (vars.boss_killed && vars.current_map != "A_Boss01" && vars.current_map != "A_Boss02" 
 	  && vars.current_map != "A_Boss03" && vars.current_map != "B_Boss01" && vars.current_map != "B_Boss02"
 	  && vars.current_map != "C_Boss01")
 	  {
 	  	vars.boss_killed = false;
 	  }
-  // house splits (if setting selected)
+  // multiwep house splits (if setting selected)
   if (settings["multiWep"] && settings["houseSplits"] && vars.current_map == "RoomOpening" && vars.old_total_seconds > vars.current_total_seconds && vars.split % vars.totalSplits == 0 && vars.split > 0)
-  {
-	  return true;
-  }
-  // routed splitting (if setting selected)
-  if (settings["routed"] && !(vars.current_map == vars.old_map)
   {
 	  return true;
   }

--- a/hades.asl
+++ b/hades.asl
@@ -86,18 +86,14 @@ update
 		if (block_name != null)
 			block_string = block_name.ToString();
 
-		// print(i.ToString() + ": " + block_string);
-
 		if (block_string == "HarpyKillPresentation")
 		{
 			vars.boss_killed = true; // boss has been killed
 		}
-
 		if (block_string == "HadesKillPresentation") 
 		{
 			vars.has_beat_hades = true;
 		}
-
 		if (block_string == "ExitToHadesPresentation")
 		{
 			vars.exit_to_hades = true;

--- a/hades.asl
+++ b/hades.asl
@@ -196,7 +196,7 @@ split
 	  if (((vars.current_map == "A_Boss01" || vars.current_map == "A_Boss02" || vars.current_map == "A_Boss03") && vars.boss_killed == 1 && vars.split % vars.totalSplits == vars.splitOffset)
 	  	||
 		// 2nd split if in lernie room and hydra killed
-	    ((vars.current_map == "B_Boss01" || vars.current_map == "B_Boss02") && vars.boss_killed == 1 && vvars.split % vars.totalSplits == 1 + vars.splitOffset)
+	    ((vars.current_map == "B_Boss01" || vars.current_map == "B_Boss02") && vars.boss_killed == 1 && vars.split % vars.totalSplits == 1 + vars.splitOffset)
 		||
 		// 3rd split if in heroes' arena and heroes are both killed 
 		(vars.current_map == "C_Boss01" && vars.boss_killed == 2 && vars.split % vars.totalSplits == 2 + vars.splitOffset)

--- a/hades.asl
+++ b/hades.asl
@@ -24,7 +24,7 @@ startup
 	});
 
   settings.Add("multiWep", false, "Multi Weapon Run");
-  settings.Add("houseSplits", false, "Use House Splits");
+  settings.Add("houseSplits", false, "Use House Splits", parent="multiWep");
   settings.Add("splitOnBossKill", false, "Split on Boss Kills");
 }
 

--- a/hades.asl
+++ b/hades.asl
@@ -61,6 +61,8 @@ init
 	vars.current_total_seconds = 0.1;
 	vars.boss_killed = 0;
 	vars.has_beat_hades = false;
+	vars.totalSplits = 5;
+	vars.splitOffset = 0;
 }
 
 update

--- a/hades.asl
+++ b/hades.asl
@@ -62,7 +62,6 @@ init
 	vars.boss_killed = 0;
 	vars.has_beat_hades = false;
 	vars.totalSplits = 5;
-	vars.splitOffset = 0;
 }
 
 update
@@ -80,11 +79,13 @@ update
 			if(block == IntPtr.Zero)
 				continue;
 			var block_name = ExtensionMethods.ReadString(game, block, 32); // Guessing on size
-			if (block_name.ToString() == "HarpyKillPresentation")
+			var block_string = block_name.ToString();
+
+			if (block_string == "HarpyKillPresentation" || block_string == "HydraKillPresentation" || block_string == "TheseusMinotaurKillPresentation")
 			{
 				vars.boss_killed++; // boss has been killed
 			}
-			if (block_name.ToString() == "HadesKillPresentation") {
+			if (block_string == "HadesKillPresentation") {
 				vars.has_beat_hades = true;
 			}
 		}
@@ -165,17 +166,7 @@ start
 	// Start the timer if in the first room and the old timer is greater than the new (memory address holds the value from the previous run)
 	if (vars.current_map == "RoomOpening" && vars.old_total_seconds > vars.current_total_seconds)
 	{
-		// Setting house split offset
-		if (settings["multiWep"] && settings["houseSplits"]) 
-		{
-			vars.totalSplits = 6;
-			vars.splitOffset = 1;
-		} 
-		else 
-		{
-			vars.totalSplits = 5;
-			vars.splitOffset = 0;
-		}
+		vars.totalSplits = 5;
 		vars.split = 0;
 		vars.boss_killed = 0;
 		return true;
@@ -185,7 +176,7 @@ start
 split
 {
   // house splits (if setting selected)
-  if (settings["multiWep"] && settings["houseSplits"] && vars.current_map == "RoomPreRun" && vars.split % vars.totalSplits == 0)
+  if (settings["multiWep"] && settings["houseSplits"] && vars.current_map == "RoomOpening" && vars.old_total_seconds > vars.current_total_seconds && vars.split % vars.totalSplits == 0 && vars.split > 0)
   {
 	  return true;
   }
@@ -193,24 +184,25 @@ split
   if (settings["splitOnBossKill"])
   {
 	  // 1st split if in fury room and boss killed
-	  if (((vars.current_map == "A_Boss01" || vars.current_map == "A_Boss02" || vars.current_map == "A_Boss03") && vars.boss_killed == 1 && vars.split % vars.totalSplits == vars.splitOffset)
+	  if (((vars.current_map == "A_Boss01" || vars.current_map == "A_Boss02" || vars.current_map == "A_Boss03") && vars.boss_killed >= 1 && vars.split % vars.totalSplits == 0)
 	  	||
 		// 2nd split if in lernie room and hydra killed
-	    ((vars.current_map == "B_Boss01" || vars.current_map == "B_Boss02") && vars.boss_killed == 1 && vars.split % vars.totalSplits == 1 + vars.splitOffset)
+	    ((vars.current_map == "B_Boss01" || vars.current_map == "B_Boss02") && vars.boss_killed >= 1 && vars.split % vars.totalSplits == 1)
 		||
 		// 3rd split if in heroes' arena and heroes are both killed 
-		(vars.current_map == "C_Boss01" && vars.boss_killed == 2 && vars.split % vars.totalSplits == 2 + vars.splitOffset)
+		(vars.current_map == "C_Boss01" && vars.boss_killed >= 2 && vars.split % vars.totalSplits == 2)
 		||
 		// 4th split if old map was the styx hub and the new room is the dad fight
-		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == 3 + vars.splitOffset)
+		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == 3)
 		||
 		// 5th and final split if Hades has been killed
-		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits == 4 + vars.splitOffset))
+		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits == 4))
 		{
 			// increment splits, reset tracking variables
 			vars.split++;
 			vars.has_beat_hades = false;
 			vars.boss_killed = 0;
+			print("bosskillsplit");
 
 			return true;
 		}
@@ -220,19 +212,19 @@ split
   {
 	// Credits: ellomenop
 	// 1st Split if old map was one of the furies fights and new room is the Tartarus -> Asphodel mid biome room
-	if (((vars.old_map == "A_Boss01" || vars.old_map == "A_Boss02" || vars.old_map == "A_Boss03") && vars.current_map == "A_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset)
+	if (((vars.old_map == "A_Boss01" || vars.old_map == "A_Boss02" || vars.old_map == "A_Boss03") && vars.current_map == "A_PostBoss01" && vars.split % vars.totalSplits == 0)
 		||
 		// 2nd Split if old map was lernie (normal or EM2) and new room is the Asphodel -> Elysium mid biome room
-		((vars.old_map == "B_Boss01" || vars.old_map == "B_Boss02") && vars.current_map == "B_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset + 1)
+		((vars.old_map == "B_Boss01" || vars.old_map == "B_Boss02") && vars.current_map == "B_PostBoss01" && vars.split % vars.totalSplits == 1)
 		||
 		// 3rd Split if old map was heroes and new room is the Elysium -> Styx mid biome room
-		(vars.old_map == "C_Boss01" && vars.current_map == "C_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset + 2)
+		(vars.old_map == "C_Boss01" && vars.current_map == "C_PostBoss01" && vars.split % vars.totalSplits == 2)
 		||
 		// 4th Split if old map was the styx hub and new room is the dad fight
-		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == vars.splitOffset + 3)
+		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == 3)
 		||
 		// 5th and final split if we have beat dad
-		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits == vars.splitOffset + 4))
+		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits ==  4))
 		{
 		vars.split++;
 

--- a/hades.asl
+++ b/hades.asl
@@ -26,6 +26,8 @@ startup
   settings.Add("multiWep", false, "Multi Weapon Run");
   settings.Add("houseSplits", false, "Use House Splits", "multiWep");
   settings.Add("splitOnBossKill", false, "Split on Boss Kills");
+  settings.Add("routed", false, "Routed (per chamber)");
+
 }
 
 init
@@ -188,6 +190,11 @@ split
 	  }
   // house splits (if setting selected)
   if (settings["multiWep"] && settings["houseSplits"] && vars.current_map == "RoomOpening" && vars.old_total_seconds > vars.current_total_seconds && vars.split % vars.totalSplits == 0 && vars.split > 0)
+  {
+	  return true;
+  }
+  // routed splitting (if setting selected)
+  if (settings["routed"] && !(vars.current_map == vars.old_map)
   {
 	  return true;
   }

--- a/hades.asl
+++ b/hades.asl
@@ -75,10 +75,17 @@ update
 	for(int i = 0; i < 4; i++)
 	{
 		IntPtr block = ExtensionMethods.ReadPointer(game, hash_table + 0x8 * i);
+
 		if(block == IntPtr.Zero)
 			continue;
+
 		var block_name = ExtensionMethods.ReadString(game, block, 32); // Guessing on size
-		var block_string = block_name.ToString();
+
+		var block_string = "";
+		
+		if (block_name != null)
+			block_string = block_name.ToString();
+
 		// print(i.ToString() + ": " + block_string);
 
 		if (block_string == "HarpyKillPresentation")
@@ -86,11 +93,13 @@ update
 			vars.boss_killed = true; // boss has been killed
 		}
 
-		if (block_string == "HadesKillPresentation") {
+		if (block_string == "HadesKillPresentation") 
+		{
 			vars.has_beat_hades = true;
 		}
 
-		if (block_string == "ExitToHadesPresentation") {
+		if (block_string == "ExitToHadesPresentation")
+		{
 			vars.exit_to_hades = true;
 		}
 	}
@@ -213,7 +222,7 @@ split
 		(vars.current_map == "C_Boss01" && vars.boss_killed && vars.split % vars.totalSplits == 2)
 		||
 		// 4th split if old map was the styx hub and the new room is the dad fight
-		(vars.exit_to_hades && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == 3)
+		(vars.exit_to_hades && vars.current_map == "D_Hub" && vars.split % vars.totalSplits == 3)
 		||
 		// 5th and final split if Hades has been killed
 		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits == 4))

--- a/hades.asl
+++ b/hades.asl
@@ -61,18 +61,6 @@ init
 	vars.current_total_seconds = 0.1;
 	vars.boss_killed = 0;
 	vars.has_beat_hades = false;
-
-	// Setting house split offset
-	if (settings["multiWep"] && settings["houseSplits]) 
-	{
-		vars.totalSplits = 6;
-		vars.splitOffset = 1;
-	}
-	else 
-	{
-		vars.totalSplits = 5;
-		vars.splitOffset = 0;
-	}
 }
 
 update
@@ -90,10 +78,13 @@ update
 			if(block == IntPtr.Zero)
 				continue;
 			var block_name = ExtensionMethods.ReadString(game, block, 32); // Guessing on size
-			if(block_name.ToString() == "HarpyKillPresentation")
+			if (block_name.ToString() == "HarpyKillPresentation")
+			{
 				vars.boss_killed++; // boss has been killed
-			else if (block_name.ToString() == "HadesKillPresentation")
+			}
+			if (block_name.ToString() == "HadesKillPresentation") {
 				vars.has_beat_hades = true;
+			}
 		}
 	}
 
@@ -172,6 +163,17 @@ start
 	// Start the timer if in the first room and the old timer is greater than the new (memory address holds the value from the previous run)
 	if (vars.current_map == "RoomOpening" && vars.old_total_seconds > vars.current_total_seconds)
 	{
+		// Setting house split offset
+		if (settings["multiWep"] && settings["houseSplits"]) 
+		{
+			vars.totalSplits = 6;
+			vars.splitOffset = 1;
+		} 
+		else 
+		{
+			vars.totalSplits = 5;
+			vars.splitOffset = 0;
+		}
 		vars.split = 0;
 		vars.boss_killed = 0;
 		return true;
@@ -216,25 +218,25 @@ split
   {
 	// Credits: ellomenop
 	// 1st Split if old map was one of the furies fights and new room is the Tartarus -> Asphodel mid biome room
-	if (((vars.old_map == "A_Boss01" || vars.old_map == "A_Boss02" || vars.old_map == "A_Boss03") && vars.current_map == "A_PostBoss01" && vars.split % 5 == vars.split % vars.totalSplits == vars.splitOffset)
+	if (((vars.old_map == "A_Boss01" || vars.old_map == "A_Boss02" || vars.old_map == "A_Boss03") && vars.current_map == "A_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset)
 		||
 		// 2nd Split if old map was lernie (normal or EM2) and new room is the Asphodel -> Elysium mid biome room
-		((vars.old_map == "B_Boss01" || vars.old_map == "B_Boss02") && vars.current_map == "B_PostBoss01" && vars.split % 5 == vars.split % vars.totalSplits == vars.splitOffset + 1)
+		((vars.old_map == "B_Boss01" || vars.old_map == "B_Boss02") && vars.current_map == "B_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset + 1)
 		||
 		// 3rd Split if old map was heroes and new room is the Elysium -> Styx mid biome room
-		(vars.old_map == "C_Boss01" && vars.current_map == "C_PostBoss01" && vars.split % 5 == vars.split % vars.totalSplits == vars.splitOffset + 2)
+		(vars.old_map == "C_Boss01" && vars.current_map == "C_PostBoss01" && vars.split % vars.totalSplits == vars.splitOffset + 2)
 		||
 		// 4th Split if old map was the styx hub and new room is the dad fight
-		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % 5 == vars.split % vars.totalSplits == vars.splitOffset + 3)
+		(vars.old_map == "D_Hub" && vars.current_map == "D_Boss01" && vars.split % vars.totalSplits == vars.splitOffset + 3)
 		||
 		// 5th and final split if we have beat dad
-		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % 5 == vars.split % vars.totalSplits == vars.splitOffset + 4))
+		(vars.current_map == "D_Boss01" && vars.has_beat_hades && vars.split % vars.totalSplits == vars.splitOffset + 4))
 		{
 		vars.split++;
 
 		// Clear this flag so that its false for the next weapon in multi-weapon runs
 		vars.has_beat_hades = false;
-		vars.boss+killed = 0;
+		vars.boss_killed = 0;
 		return true;
 		}
   }

--- a/hades.asl
+++ b/hades.asl
@@ -73,15 +73,16 @@ update
 	if(last_block_count != vars.current_block_count)
 	{
 		IntPtr hash_table = ExtensionMethods.ReadPointer(game, vars.current_player + 0x40);
-		for(int i = 0; i < 2; i++)
+		for(int i = 0; i < vars.current_block_count; i++)
 		{
 			IntPtr block = ExtensionMethods.ReadPointer(game, hash_table + 0x8 * i);
 			if(block == IntPtr.Zero)
 				continue;
 			var block_name = ExtensionMethods.ReadString(game, block, 32); // Guessing on size
 			var block_string = block_name.ToString();
+			print(block_string);
 
-			if (block_string == "HarpyKillPresentation" || block_string == "HydraKillPresentation" || block_string == "TheseusMinotaurKillPresentation")
+			if (block_string == "HarpyKillPresentation")
 			{
 				vars.boss_killed++; // boss has been killed
 			}

--- a/hades.asl
+++ b/hades.asl
@@ -24,7 +24,7 @@ startup
 	});
 
   settings.Add("multiWep", false, "Multi Weapon Run");
-  settings.Add("houseSplits", false, "Use House Splits", parent="multiWep");
+  settings.Add("houseSplits", false, "Use House Splits", "multiWep");
   settings.Add("splitOnBossKill", false, "Split on Boss Kills");
 }
 


### PR DESCRIPTION
- Routed split logic by Museus
- Splits on boss kills includes splitting on interaction with door to exit Styx to go to Hades fight.
- Main change to detect HarpyKillPresentation consistently was to increase block loop iteration limit to 4 from 2, and to remove block size changing check.

(please feel free to squash these into one commit)