### PR TITLE
URGENT: Bugfix for failing to split in Styx on "old" splitting strategy

### DIFF
--- a/hades.asl
+++ b/hades.asl
@@ -253,7 +253,7 @@ split
 
 		// Clear this flag so that its false for the next weapon in multi-weapon runs
 		vars.has_beat_hades = false;
-		vars.boss_killed = 0;
+		vars.boss_killed = false;
 		return true;
 		}
   }
@@ -269,7 +269,7 @@ reset
 		vars.time_split = "0:0.1".Split(':', '.');
 		vars.current_total_seconds = .1;
 		vars.has_beat_hades = false;
-		vars.boss_killed = 0;
+		vars.boss_killed = false;
 		return true;
 	}
 }


### PR DESCRIPTION
Missed this when testing somehow, setting this variable to 0 some places and false others (hangover of a design I tried) caused the split method to crash. This only was an issue when there was a split not preceded by a boss kill (styx) so it was breaking at that split. I have tested repeatedly with this fix and this should take care of it.